### PR TITLE
書籍を40件以上検索できるようにする

### DIFF
--- a/App/Books/templates/book_search.html
+++ b/App/Books/templates/book_search.html
@@ -12,14 +12,13 @@
     <div class="card card-container mb-auto" id="searchform">
         <h5 class="card-header">検索</h5>
         <div class="card-body">
-            <form action="{% url 'Books:book_search'%}" method="post" class="text-center form-signin">
-                {% csrf_token %}
+            <form action="#" class="text-center form-signin">
                 <div class="form-group row">
                     <label for="author" class="col-sm-2 col-form-label ">
                         <h5>著者</h5>
                     </label>
                     <div class="col-sm-10">
-                        <input type="text" class="form-control" id="author" value="" name="auth">
+                        <input type="text" class="form-control" id="author" name="auth">
                     </div>
                 </div>
                 <div class="form-group row">
@@ -32,14 +31,16 @@
                         <input type="text" class="form-control" id="title" placeholder="" name="title">
                     </div>
                 </div>
-                <button class="btn btn-lg btn-primary btn-block btn-signin" type="submit">検索</button>
+                <button class="btn btn-lg btn-primary btn-block btn-signin searcbutton" id="top_searchbutton"
+                    type="button">検索</button>
+                <p class="err_msg"></p>
         </div>
         </form>
     </div>
 </div>
 
 <!-- 検索結果 -->
-<div class="container-lg">
+<div class="container-lg mb-5">
     <!-- <h3>検索結果</h3> -->
     <div class="row row-cols-1 row-cols-md-1 row-cols-lg-2 row-cols-xl-3 g-4" id="searchresult">
         {% for data in datas %}
@@ -74,13 +75,131 @@
                     </div>
                 </div>
             </form>
-
         </div>
 
         {% endfor %}
+    </div>
+    <div id="more_search_button" class="text-center">
+        <button type="button" class="btn btn-outline-normal searcbutton">
+            <span class="material-icons big-circle">
+                arrow_drop_down_circle
+            </span>
+            さらに検索
+        </button>
     </div>
 </div>
 
 {% endblock %}
 {% block scripts %}
+<script>
+    // djangoでajaxを使う為のの設定
+    function getCookie(name) {
+        var cookieValue = null;
+        if (document.cookie && document.cookie !== '') {
+            var cookies = document.cookie.split(';');
+            for (var i = 0; i < cookies.length; i++) {
+                var cookie = cookies[i].trim();
+                // Does this cookie string begin with the name we want?
+                if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                    cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                    break;
+                }
+            }
+        }
+        return cookieValue;
+    }
+    var csrftoken = getCookie('csrftoken');
+    function csrfSafeMethod(method) {
+        // these HTTP methods do not require CSRF protection
+        return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+    }
+    $.ajaxSetup({
+        beforeSend: function (xhr, settings) {
+            if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+                xhr.setRequestHeader("X-CSRFToken", csrftoken);
+            }
+        }
+    });
+
+    // データが無い時は更に検索ボタンを隠す
+    function display_more_search() {
+        if ($("#searchresult form").length == 0) {
+            $("#more_search_button").css("display", "none");
+        }
+        else if ($(".err_msg").text() != "") {
+            $("#more_search_button").css("display", "none");
+        }
+        else {
+            $("#more_search_button").show();
+        }
+    }
+
+
+    var next_int = 0;
+    display_more_search();
+    $("#top_searchbutton").on("click", function () {
+        next_int = 0;
+        $("#searchresult").empty();
+    });
+
+    $(".searcbutton").on("click", function () {
+        // ajaxでデータ取得 と next_int　の更新
+        var auth = $("#author").val();
+        var title = $("#title").val();
+        $.ajax({
+            url: "{% url 'Books:book_search' %}",
+            method: "POST",
+            data: {
+                author: auth,
+                title: title,
+                next_int: next_int
+            },
+            timeout: 5000,
+        })
+            .done(function (result) {
+                $(".err_msg").text("")
+                var datas = result.datas;
+                next_int += 1;
+                for (var i in datas) {
+                    var data = datas[i];
+                    var authors = data.authors;
+                    $("#searchresult").append(
+                        $('<div/>', { 'class': 'col' }).append(
+                            $('<form/>', { 'action': "{% url 'Books:detail'%}", 'method': "post" }).append(
+                                '{% csrf_token %}',
+                                $('<input/>', { type: 'hidden', value: data.title, name: 'title' }),
+                                $('<input/>', { type: "hidden", value: JSON.stringify(data.imageLinks), name: "imageLinks" }),
+                                $('<input/>', { type: "hidden", value: data.description, name: "description" }),
+                                $('<input/>', { type: "hidden", value: data.authors, name: "authors" }),
+                                $('<input/>', { type: "hidden", value: data.publishedDate, name: "publishedDate" }),
+                                $('<input/>', { type: "hidden", value: data.pageCount, name: "pageCount" }),
+                                $('<div/>', { class: 'card mb-3' }).append(
+                                    $('<div/>', { class: "row g-0" }).append(
+                                        $('<div/>', { class: "col-sm-4" }).append(
+                                            $('<button/>', { type: "submit" }).append(
+                                                $('<img/>', { src: data.imageLinks.thumbnail, alt: "thumbnail" })
+                                            )
+                                        ),
+                                        $('<div/>', { class: "col-sm-8" }).append(
+                                            $('<div/>', { class: "card-body" }).append(
+                                                $('<h5/>', { class: "cart-title", text: data.title }),
+                                                $('<p/>', { class: "card-text", test: authors + "著" })
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    );
+                }
+                display_more_search();
+            })
+            .fail(function (data) {
+                $(".err_msg").text(data.responseJSON.error);
+                display_more_search();
+                $('body, html').animate({ scrollTop: 0 }, 100);
+                return false;
+            })
+    })
+</script>
 {% endblock %}

--- a/App/Login/views.py
+++ b/App/Login/views.py
@@ -1,4 +1,4 @@
-import json
+import inspect
 from django.http.response import JsonResponse
 from django.shortcuts import render, redirect
 from django.contrib.auth import login, logout
@@ -146,7 +146,7 @@ def delete_attr(request):
             attr.delete()
             data = make_user_config_data(username)
         except Exception as e:
-            print(e)
+            print(f"{inspect.currentframe().f_back.f_code.co_filename},{inspect.currentframe().f_back.f_lineno},{e}")
             data = make_user_config_data(username)
             data["msg"] = "削除に失敗"
             return render(request, "config.html", data)

--- a/App/static/css/Books/book_search.css
+++ b/App/static/css/Books/book_search.css
@@ -22,3 +22,6 @@
     -webkit-box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.3);
     box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.3);
 }
+.big-circle{
+    font-size: 45px;
+}

--- a/App/utils/api_search.py
+++ b/App/utils/api_search.py
@@ -1,3 +1,4 @@
+import inspect
 import requests, json
 
 
@@ -5,7 +6,7 @@ class GoogleBooksStrs:
     """
     google book apiからデータを取り出すときに使う文字列を定義するクラス
     """
-    totalitems = "totalitems"
+    totalitems = "totalItems"
     volumeinfo = "volumeInfo"
     title = "title"
     authors = "authors"
@@ -17,10 +18,10 @@ class GoogleBooksStrs:
     imageLinks = "imageLinks"
     description = 'description'
     thumbnail = "thumbnail"
-    result_keys = [title, authors, publisheddate, pagecount, industryIdentifiers, imageLinks, description]
+    result_keys = [title,totalitems, authors, publisheddate, pagecount, industryIdentifiers, imageLinks, description]
     
 
-def search_from_params(auth:str="", title:str="")->list[dict]:
+def search_from_params(auth:str="", title:str="", startindex:int=0)->list[dict]:
     """[summary]
     作者、題名をクエリパラメータとして、googlebooks api でデータを検索する。
     Args:
@@ -31,7 +32,7 @@ def search_from_params(auth:str="", title:str="")->list[dict]:
         [list[dict]]: dict のkey はGoogleBooksStrs.result_keys
         auth, titleが空の時は空のリストを返す
     """
-    url = create_query_string(auth=auth, title=title)
+    url = create_query_string(auth=auth, title=title, startindex=startindex)
     if url == "":
         return list({})
     res = requests.get(url).json()
@@ -40,7 +41,7 @@ def search_from_params(auth:str="", title:str="")->list[dict]:
     
 
 
-def create_query_string(title="", auth="")->str:
+def create_query_string(title:str="", auth:str="", startindex:int=0)->str:
     """
     googlebooksapiでデータを取得する為のurlを作成する
 
@@ -65,16 +66,32 @@ def create_query_string(title="", auth="")->str:
         q2 = "intitle:" + title
         url+= q1 + "+" + q2
     url +=  "&maxResults=40"
+    url += f"&startIndex={startindex}"
     return url
 
-def get_result_list(response:dict, author:str="")-> list[dict]:
-    if response['totalItems'] == 0:
-        return list({})
+def get_result_list(response:dict, author:str="", startIndex:int=0)-> list[dict]:
+    """[summary]GoogleBooksApiで取ってきたjsonデータを使いやすい形にまとめる関数
+
+    Args:
+        response (dict): GoogleBooksApi で取ってきたデータ
+        author (str, optional): 著者を指定したい時の変数 Defaults to "".
+        startIndex (int, optional): startIndexに指定する値. Defaults to 0.
+
+    Returns:
+        list[dict]: GoogleBooksStrs.result_keys に指定されている値をkeyにした辞書をlistにする
+    """
+    totalitems = GoogleBooksStrs.totalitems
     result_dict =[]
-    items = response["items"]
+    items = response.get("items", None)
+
+    # データが無い時は空データを返す
+    if items == None:
+        return list({})
+
     for item in items:
         item_volume = item[GoogleBooksStrs.volumeinfo]
         dic = {}
+        dic[totalitems] = response[totalitems]
         for k in GoogleBooksStrs.result_keys:
             if k in item_volume.keys():
                 dic[k]=item_volume[k]
@@ -82,11 +99,19 @@ def get_result_list(response:dict, author:str="")-> list[dict]:
                 dic[k] = []
             elif k not in item_volume.keys() and  k == GoogleBooksStrs.imageLinks:
                 dic[k] = {'thumbnail':"/static/noimage.png"}
+            elif k == GoogleBooksStrs.totalitems :
+                pass
             else:
                 dic[k] = ""
+        # authors はリストからstr(カンマ区切り)にする
+        if len(dic[GoogleBooksStrs.authors]) > 1:
+            dic[GoogleBooksStrs.authors] =",".join(dic[GoogleBooksStrs.authors])
+        elif len(dic[GoogleBooksStrs.authors]) == 1:
+            dic[GoogleBooksStrs.authors] =dic[GoogleBooksStrs.authors][0]
+
         # author 指定がある時は、authorが空の場所にauthorを挿入する
         if author != "" and ( dic[GoogleBooksStrs.authors] in [[], None, ""]):
-            dic[GoogleBooksStrs.authors] =[author]
+            dic[GoogleBooksStrs.authors] = author
 
         result_dict.append(dic)
     return result_dict


### PR DESCRIPTION
Fixes #54
４０件以上検索結果がある時は、ページ最下部に矢印アイコンを表示して、クリックすると検索するようにした。
検索結果がなくなるまで検索したら、エラーを表示して、画面一番上にフォーカス